### PR TITLE
Implement __repr__() into some classes

### DIFF
--- a/kmy/account.py
+++ b/kmy/account.py
@@ -18,6 +18,9 @@ class Account:
         self.id: str = ""
         self.subAccounts: List[SubAccount] = []
 
+    def __repr__(self):
+        return f"{self.__class__.__name__}(name='{self.name}', currency={self.currency})"
+
     @classmethod
     def from_xml(cls, node):
         account = cls()

--- a/kmy/fileinfo.py
+++ b/kmy/fileinfo.py
@@ -5,6 +5,9 @@ class FileInfo:
         self.version: str = ""
         self.fixVersion: str = ""
 
+    def __repr__(self):
+        return f"{self.__class__.__name__}(creationDate='{self.creationDate}', lastModifiedDate={self.lastModifiedDate})"
+
     @classmethod
     def from_xml(cls, node):
         file_info = cls()

--- a/kmy/institution.py
+++ b/kmy/institution.py
@@ -13,6 +13,9 @@ class Institution:
         self.accountIds: List[str] = []
         self.keyValuePairs = []
 
+    def __repr__(self):
+        return f"{self.__class__.__name__}(name='{self.name}')"
+
     @classmethod
     def from_xml(cls, node):
         institution = cls()

--- a/kmy/kmy.py
+++ b/kmy/kmy.py
@@ -23,6 +23,9 @@ class Kmy:
         self.accounts: List[Account] = []
         self.transactions: List[Transaction] = []
 
+    def __repr__(self):
+        return f"{self.__class__.__name__}(fileInfo='{self.fileInfo}', user={self.user})"
+
     @classmethod
     def from_xml(cls, node):
         kmy: Kmy = cls()

--- a/kmy/payee.py
+++ b/kmy/payee.py
@@ -10,6 +10,9 @@ class Payee:
         self.matchingEnabled: bool = False
         self.address: PayeeAddress = PayeeAddress()
 
+    def __repr__(self):
+        return f"{self.__class__.__name__}(name='{self.name}')"
+
     @classmethod
     def from_xml(cls, node):
         payee = cls()

--- a/kmy/split.py
+++ b/kmy/split.py
@@ -13,6 +13,9 @@ class Split:
         self.reconcileDate: str = ""
         self.id: str = ""
 
+    def __repr__(self):
+        return f"{self.__class__.__name__}(payee='{self.payee}', value='{self.value}')"
+
     @classmethod
     def from_xml(cls, node):
         split = cls()

--- a/kmy/subaccount.py
+++ b/kmy/subaccount.py
@@ -2,6 +2,9 @@ class SubAccount:
     def __init__(self):
         self.id: str = ""
 
+    def __repr__(self):
+        return f"{self.__class__.__name__}(id='{self.id}')"
+
     @classmethod
     def from_xml(cls, node):
         subaccount = cls()

--- a/kmy/tag.py
+++ b/kmy/tag.py
@@ -5,6 +5,9 @@ class Tag:
         self.name: str = ""
         self.id: str = ""
 
+    def __repr__(self):
+        return f"{self.__class__.__name__}(name='{self.name}')"
+
     @classmethod
     def from_xml(cls, node):
         tag = cls()

--- a/kmy/transaction.py
+++ b/kmy/transaction.py
@@ -12,6 +12,9 @@ class Transaction:
         self.id: str = ""
         self.splits: List[Split] = []
 
+    def __repr__(self):
+        return f"{self.__class__.__name__}(postDate='{self.postDate}', memo='{self.memo}')"
+
     @classmethod
     def from_xml(cls, node):
         transaction = cls()

--- a/kmy/user.py
+++ b/kmy/user.py
@@ -7,6 +7,9 @@ class User(object):
         self.name: str = ""
         self.address: UserAddress = UserAddress()
 
+    def __repr__(self):
+        return f"{self.__class__.__name__}(name='{self.name}')"
+
     @classmethod
     def from_xml(cls, node):
         user = cls()


### PR DESCRIPTION
Fixes issue #1.

This PR adds the `__repr__()` method to a few classes in order to allow them to be better displayed when evaluated in a REPL or console output.