### PR TITLE
Extend data model, allow for uncompressed files

### DIFF
--- a/kmy/account.py
+++ b/kmy/account.py
@@ -1,5 +1,7 @@
+from typing import Dict
 from typing import List
 
+from .pairs import pairs_dict_from_xml
 from .subaccount import SubAccount
 
 
@@ -17,6 +19,7 @@ class Account:
         self.opened: str = ""
         self.id: str = ""
         self.subAccounts: List[SubAccount] = []
+        self.keyValuePairs: Dict[str, str] = {}
 
     def __repr__(self):
         return f"{self.__class__.__name__}(name='{self.name}', currency={self.currency})"
@@ -44,3 +47,4 @@ class Account:
             for subaccount_node in subaccount_nodes:
                 subaccount = SubAccount.from_xml(subaccount_node)
                 self.subAccounts.append(subaccount)
+        self.keyValuePairs = pairs_dict_from_xml(node.find('KEYVALUEPAIRS'))

--- a/kmy/institution.py
+++ b/kmy/institution.py
@@ -1,6 +1,8 @@
+from typing import Dict
 from typing import List
 
 from .institutionaddress import InstitutionAddress
+from .pairs import pairs_dict_from_xml
 
 
 class Institution:
@@ -11,7 +13,7 @@ class Institution:
         self.manager: str = ""
         self.address: InstitutionAddress = InstitutionAddress()
         self.accountIds: List[str] = []
-        self.keyValuePairs = []
+        self.keyValuePairs: Dict[str, str] = {}
 
     def __repr__(self):
         return f"{self.__class__.__name__}(name='{self.name}')"
@@ -33,3 +35,4 @@ class Institution:
         account_id_nodes = node.find('ACCOUNTIDS')
         for account_id_node in account_id_nodes:
             self.accountIds.append(account_id_node.attrib['id'])
+        self.keyValuePairs = pairs_dict_from_xml(node.find('KEYVALUEPAIRS'))

--- a/kmy/kmy.py
+++ b/kmy/kmy.py
@@ -1,11 +1,13 @@
 import gzip
 import xml.etree.ElementTree as elementTree
+from typing import Dict
 from typing import List
 
 from .account import Account
 from .costcenter import CostCenter
 from .fileinfo import FileInfo
 from .institution import Institution
+from .pairs import pairs_dict_from_xml
 from .payee import Payee
 from .tag import Tag
 from .transaction import Transaction
@@ -22,6 +24,7 @@ class Kmy:
         self.tags: List[Tag] = []
         self.accounts: List[Account] = []
         self.transactions: List[Transaction] = []
+        self.keyValuePairs: Dict[str, str] = {}
 
     def __repr__(self):
         return f"{self.__class__.__name__}(fileInfo='{self.fileInfo}', user={self.user})"
@@ -59,6 +62,7 @@ class Kmy:
         for transaction_node in transaction_nodes:
             transaction = Transaction.from_xml(transaction_node)
             self.transactions.append(transaction)
+        self.keyValuePairs = pairs_dict_from_xml(node.find('KEYVALUEPAIRS'))
 
     @classmethod
     def from_kmy_file(cls, file_name):

--- a/kmy/kmy.py
+++ b/kmy/kmy.py
@@ -66,8 +66,13 @@ class Kmy:
 
     @classmethod
     def from_kmy_file(cls, file_name):
-        with gzip.open(file_name, 'rb') as file:
+        file_open = gzip.open if is_gz_file(file_name) else open
+        with file_open(file_name, 'rb') as file:
             tree = elementTree.parse(file)
         root = tree.getroot()
         kmm = Kmy.from_xml(root)
         return kmm
+
+def is_gz_file(filepath):
+    with open(filepath, 'rb') as test_f:
+        return test_f.read(2) == b'\x1f\x8b'

--- a/kmy/pairs.py
+++ b/kmy/pairs.py
@@ -1,0 +1,7 @@
+def pairs_dict_from_xml(pair_nodes):
+    if pair_nodes is None:
+        return {}
+    result = {}
+    for pair_node in pair_nodes:
+        result[pair_node.attrib["key"]] = pair_node.attrib["value"]
+    return result

--- a/kmy/payee.py
+++ b/kmy/payee.py
@@ -1,3 +1,6 @@
+from typing import Dict
+from typing import List
+
 from .payeeaddress import PayeeAddress
 
 
@@ -9,6 +12,9 @@ class Payee:
         self.id: str = ""
         self.matchingEnabled: bool = False
         self.address: PayeeAddress = PayeeAddress()
+        self.payeeIdentifiers: List[Dict[str, str]] = list()
+        self.usingMatchkey: bool = False
+        self.matchkeys: List[str]
 
     def __repr__(self):
         return f"{self.__class__.__name__}(name='{self.name}')"
@@ -25,6 +31,25 @@ class Payee:
         self.email = node.attrib['email']
         self.id = node.attrib['id']
         self.matchingEnabled = (node.attrib['matchingenabled'] != '0')
+        self.usingMatchkey = (node.attrib["usingmatchkey"] != "0") if "usingmatchkey" in node.attrib else False
+        self.matchkeys = node.attrib["matchkey"].split("&#xa;") if "matchkeys" in node.attrib else []
         address_node = node.find('ADDRESS')
         if address_node is not None:
             self.address = PayeeAddress.from_xml(address_node)
+        payee_identifier_nodes = node.findall("payeeIdentifier")
+        if payee_identifier_nodes is not None:
+            for payee_identifier_node in payee_identifier_nodes:
+                self.payeeIdentifiers.append(payee_identifier_node.attrib.copy())
+
+    def matched_by(self, **kwargs: Dict[str, str]) -> bool:
+        def is_match(candidate: Dict[str, str]) -> bool:
+            for key, val in kwargs.items():
+                if candidate.get(key, None) != val:
+                    return False
+            return True
+
+        for identifier in self.payeeIdentifiers:
+            if is_match(identifier):
+                return True
+
+        return False


### PR DESCRIPTION
This PR pools 2 additions to the data model and 1 improvement on file handling:

1. Add support for key-value-pairs: The kMyMoney data model comprises lists of key-value-pairs for Account, Institution and the kmy-file itself. E.g. Accounts use keyValuePairs to store information like IBAN with the account. The PR adds a data field to the respective class and code to init_from_xml() for initialization. A generic parser function pairs_dict_from_xml() is provided to avoid code duplication. 
2. Add support for Payee identifiers: In kMyMoney, Payee identifiers are rules used to identify a payee when importing transaction data (e.g. from a CSV file).  The PR adds new datafields to the Payee class and init code to init_from_xml() as well as a utility function to query if a payee matches a given criteria (e.g. combinations of iban, account_number, bank_number)
3. For kMyMoney, it makes no difference, if the Kmy-file is (gzip) compressed or uncompressed when opening the file. This PR allows the Kmy class to behave identically, by choosing gzip_open() or open(), after checking the file for the gzip marker.

Please let me know if you rather prefer individual PRs 